### PR TITLE
Allow credentials and only localhost during dev

### DIFF
--- a/internal/transport/http/mid.go
+++ b/internal/transport/http/mid.go
@@ -12,9 +12,10 @@ import (
 func JSONMiddleware(next http.Handler) http.Handler {
 	if os.Getenv("API_MODE") == "dev" {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.Header().Set("Access-Control-Allow-Origin", "https://deft-torte-4578e5.netlify.app, http://localhost:8100/")
+			w.Header().Set("Access-Control-Allow-Origin", "http://localhost:8100")
 			w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS")
 			w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Access-Control-Allow-Headers, Authorization, X-Requested-With")
+			w.Header().Set("Access-Control-Allow-Credentials", "true")
 			if r.Method == "OPTIONS" {
 				w.WriteHeader(http.StatusOK)
 				return


### PR DESCRIPTION
- Allowed credential to be sent with requests in local development.
- Only allow localhost client to make requests to the local dev server.